### PR TITLE
Annotate component properties and show component name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Variant Annotator
 
-Annotate variant properties for multiple components. Just select component instances and run the plugin. A text box is generated with variant properties for every selection. This makes annotating components a breeze, especially while creating component specifications.
+Annotate variant and component properties for multiple components. Just select component instances and run the plugin. A text box is generated with the component name and its properties for every selection. This makes annotating components a breeze, especially while creating component specifications.

--- a/code.js
+++ b/code.js
@@ -1,60 +1,56 @@
-// Check if the user has selected an object that's not a component instance 
-if (figma.currentPage.selection.length === 0) {
-    figma.closePlugin("Nothing selected. Please select component instances to annotate.")
-}
-
-async function main() {
-
-    await figma.loadFontAsync({
-        family: 'Inter',
-        style: 'Regular',
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-
-    const selectedInstance = figma.currentPage.selection;
-    //console.log(selectedInstance);
-    selectedInstance.forEach(runAnnotator);
-
-    function runAnnotator(item, index, arr) {
-        
-        if (item.type !== 'INSTANCE') {
-            figma.closePlugin("Please select ONLY component instances to annotate.")
-        }
-
-        if (item.variantProperties === null) {
-            figma.closePlugin("No variant properties found.")
-        } 
-        
-        else if (item.type === 'INSTANCE')  {
-        //console.log(item);
-        let positionX = (item.absoluteRenderBounds.x);
-        let positionY = (item.absoluteRenderBounds.y) - 80;
-        //console.log(positionX,positionY);
-        const instancePropInfo = item.variantProperties;
-        //console.log(instancePropInfo);
-
-        var propString = '';
-        for (let key in instancePropInfo) {
-        //console.log(key + ':' + theme[key]);
-        if (!propString) {
-            propString = key + ':' + instancePropInfo[key];
-        } else {
-            propString += '\n' + key + ':' + instancePropInfo[key];
-        }
-        }
-        //console.log(propString);
-
-        const nodes = [];
-        const text = figma.createText();
-        text.fontSize = 16;
-        text.characters = propString;
-        text.x = positionX;
-        text.y = positionY-(text.absoluteRenderBounds.height);
-        figma.currentPage.appendChild(text);
-        nodes.push(text);
-        figma.closePlugin("Annotating Variants");
-    }
-    }
-
+};
+if (figma.currentPage.selection.length === 0) {
+    figma.closePlugin("Nothing selected. Please select component instances to annotate.");
 }
-
+function main() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+        yield figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
+        const selectedInstances = figma.currentPage.selection;
+        for (const item of selectedInstances) {
+            if (item.type !== 'INSTANCE') {
+                figma.closePlugin('Please select ONLY component instances to annotate.');
+                return;
+            }
+            const variantProps = item.variantProperties || {};
+            const componentProps = item.componentProperties || {};
+            const hasVariantProps = Object.keys(variantProps).length > 0;
+            const hasComponentProps = Object.keys(componentProps).length > 0;
+            if (!hasVariantProps && !hasComponentProps) {
+                figma.closePlugin('No variant or component properties found.');
+                return;
+            }
+            const positionX = item.absoluteRenderBounds.x;
+            const positionY = item.absoluteRenderBounds.y - 80;
+            const componentName = item.mainComponent ? item.mainComponent.name : item.name;
+            const lines = [componentName];
+            for (const key in variantProps) {
+                lines.push(`${key}: ${variantProps[key]}`);
+            }
+            for (const key in componentProps) {
+                const prop = componentProps[key];
+                const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
+                lines.push(`${key}: ${value}`);
+            }
+            const propString = lines.join('\n');
+            const text = figma.createText();
+            text.fontName = { family: 'Inter', style: 'Regular' };
+            text.fontSize = 16;
+            text.characters = propString;
+            text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
+            figma.currentPage.appendChild(text);
+            text.x = positionX;
+            text.y = positionY - text.height;
+        }
+        figma.closePlugin('Annotating Variants');
+    });
+}
 main();

--- a/code.ts
+++ b/code.ts
@@ -1,1 +1,58 @@
-// This is an empty file. I straightaway was writing code on JS. My bad.
+if (figma.currentPage.selection.length === 0) {
+  figma.closePlugin("Nothing selected. Please select component instances to annotate.");
+}
+
+async function main() {
+  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
+
+  const selectedInstances = figma.currentPage.selection;
+
+  for (const item of selectedInstances) {
+    if (item.type !== 'INSTANCE') {
+      figma.closePlugin('Please select ONLY component instances to annotate.');
+      return;
+    }
+
+    const variantProps = item.variantProperties || {};
+    const componentProps: { [key: string]: any } = (item as any).componentProperties || {};
+
+    const hasVariantProps = Object.keys(variantProps).length > 0;
+    const hasComponentProps = Object.keys(componentProps).length > 0;
+    if (!hasVariantProps && !hasComponentProps) {
+      figma.closePlugin('No variant or component properties found.');
+      return;
+    }
+
+    const positionX = item.absoluteRenderBounds!.x;
+    const positionY = item.absoluteRenderBounds!.y - 80;
+    const componentName = item.mainComponent ? item.mainComponent.name : item.name;
+
+    const lines: string[] = [componentName];
+
+    for (const key in variantProps) {
+      lines.push(`${key}: ${variantProps[key]}`);
+    }
+
+    for (const key in componentProps) {
+      const prop = componentProps[key];
+      const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
+      lines.push(`${key}: ${value}`);
+    }
+
+    const propString = lines.join('\n');
+
+    const text = figma.createText();
+    text.fontName = { family: 'Inter', style: 'Regular' };
+    text.fontSize = 16;
+    text.characters = propString;
+    text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
+    figma.currentPage.appendChild(text);
+    text.x = positionX;
+    text.y = positionY - text.height;
+  }
+
+  figma.closePlugin('Annotating Variants');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Display selected component's name as a bold title above its variant annotations.
- Include component property values alongside variant properties when generating annotations.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb7935d024832897ac2240956f6bac