### PR TITLE
Skip variant entries in component annotations

### DIFF
--- a/code.js
+++ b/code.js
@@ -37,6 +37,9 @@ function main() {
             }
             for (const key in componentProps) {
                 const prop = componentProps[key];
+                if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
+                    continue;
+                }
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
                 lines.push(`${key}: ${value}`);
             }

--- a/code.ts
+++ b/code.ts
@@ -36,6 +36,9 @@ async function main() {
 
     for (const key in componentProps) {
       const prop = componentProps[key];
+      if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
+        continue;
+      }
       const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
       lines.push(`${key}: ${value}`);
     }


### PR DESCRIPTION
## Summary
- avoid duplicating variant properties by skipping component props whose type is VARIANT
- rebuild TypeScript output

## Testing
- `npm run build`
- `node - <<'NODE'
const variantProps = { Variant: 'A' };
const componentProps = {
  Variant: { type: 'VARIANT', value: 'A' },
  Enabled: { type: 'BOOLEAN', value: true },
};
const lines = ['Component'];
for (const key in variantProps) { lines.push(`${key}: ${variantProps[key]}`); }
for (const key in componentProps) {
  const prop = componentProps[key];
  if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') { continue; }
  const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
  lines.push(`${key}: ${value}`);
}
console.log(lines.join('\n'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bb810dcb988328b73bd841425b0d1c