### PR TITLE
Use component property definitions for readable annotations

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,84 +1,73 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 if (figma.currentPage.selection.length === 0) {
-    figma.closePlugin("Nothing selected. Please select component instances to annotate.");
+  figma.closePlugin("Nothing selected. Please select component instances to annotate.");
 }
-function main() {
-    var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        yield figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
-        yield figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
-        const selectedInstances = figma.currentPage.selection;
-        for (const item of selectedInstances) {
-            if (item.type !== 'INSTANCE') {
-                figma.closePlugin('Please select ONLY component instances to annotate.');
-                return;
-            }
-            const variantProps = item.variantProperties || {};
-            const componentProps = item.componentProperties || {};
-            const hasVariantProps = Object.keys(variantProps).length > 0;
-            const hasComponentProps = Object.keys(componentProps).length > 0;
-            if (!hasVariantProps && !hasComponentProps) {
-                figma.closePlugin('No variant or component properties found.');
-                return;
-            }
-            const positionX = item.absoluteRenderBounds.x;
-            const positionY = item.absoluteRenderBounds.y - 80;
-            const mainComponent = item.mainComponent;
-            const componentName = mainComponent &&
-                ((_a = mainComponent.parent) === null || _a === void 0 ? void 0 : _a.type) === 'COMPONENT_SET' &&
-                item.name === mainComponent.name
-                ? mainComponent.parent.name
-                : item.name;
-            const propDefinitions = (mainComponent === null || mainComponent === void 0 ? void 0 : mainComponent.componentPropertyDefinitions) || {};
-            const keyNameMap = {};
-            for (const key in propDefinitions) {
-                const def = propDefinitions[key];
-                if (def && typeof def === 'object' && 'name' in def) {
-                    keyNameMap[key] = def.name;
-                }
-            }
-            const getPropName = (key) => keyNameMap[key] || key;
-            const lines = [];
-            const seen = new Set();
-            const addLine = (line) => {
-                if (!seen.has(line)) {
-                    lines.push(line);
-                    seen.add(line);
-                }
-            };
-            addLine(componentName);
-            for (const key in variantProps) {
-                const name = getPropName(key);
-                addLine(`${name}: ${variantProps[key]}`);
-            }
-            for (const key in componentProps) {
-                const prop = componentProps[key];
-                if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
-                    continue;
-                }
-                const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-                const name = getPropName(key);
-                addLine(`${name}: ${value}`);
-            }
-            const propString = lines.join('\n');
-            const text = figma.createText();
-            text.fontName = { family: 'Inter', style: 'Regular' };
-            text.fontSize = 16;
-            text.characters = propString;
-            text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
-            figma.currentPage.appendChild(text);
-            text.x = positionX;
-            text.y = positionY - text.height;
-        }
-        figma.closePlugin('Annotating Variants');
-    });
+async function main() {
+  var _a;
+  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
+  const selectedInstances = figma.currentPage.selection;
+  for (const item of selectedInstances) {
+    if (item.type !== 'INSTANCE') {
+      figma.closePlugin('Please select ONLY component instances to annotate.');
+      return;
+    }
+    const variantProps = item.variantProperties || {};
+    const componentProps = item.componentProperties || {};
+    const hasVariantProps = Object.keys(variantProps).length > 0;
+    const hasComponentProps = Object.keys(componentProps).length > 0;
+    if (!hasVariantProps && !hasComponentProps) {
+      figma.closePlugin('No variant or component properties found.');
+      return;
+    }
+    const positionX = item.absoluteRenderBounds.x;
+    const positionY = item.absoluteRenderBounds.y - 80;
+    const mainComponent = item.mainComponent;
+    const componentName = mainComponent &&
+      ((_a = mainComponent.parent) === null || _a === void 0 ? void 0 : _a.type) === 'COMPONENT_SET' &&
+      item.name === mainComponent.name
+      ? mainComponent.parent.name
+      : item.name;
+    const propDefinitions = (mainComponent === null || mainComponent === void 0 ? void 0 : mainComponent.componentPropertyDefinitions) || {};
+    const keyNameMap = {};
+    for (const key in propDefinitions) {
+      const def = propDefinitions[key];
+      if (def && typeof def === 'object' && 'name' in def) {
+        keyNameMap[key] = def.name;
+      }
+    }
+    const getPropName = (key) => keyNameMap[key] || key;
+    const lines = [];
+    const seen = new Set();
+    const addLine = (line) => {
+      if (!seen.has(line)) {
+        lines.push(line);
+        seen.add(line);
+      }
+    };
+    addLine(componentName);
+    for (const key in variantProps) {
+      const name = getPropName(key);
+      addLine(`${name}: ${variantProps[key]}`);
+    }
+    for (const key in componentProps) {
+      const prop = componentProps[key];
+      if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
+        continue;
+      }
+      const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
+      const name = getPropName(key);
+      addLine(`${name}: ${value}`);
+    }
+    const propString = lines.join('\n');
+    const text = figma.createText();
+    text.fontName = { family: 'Inter', style: 'Regular' };
+    text.fontSize = 16;
+    text.characters = propString;
+    text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
+    figma.currentPage.appendChild(text);
+    text.x = positionX;
+    text.y = positionY - text.height;
+  }
+  figma.closePlugin('Annotating Variants');
 }
 main();

--- a/code.js
+++ b/code.js
@@ -37,9 +37,19 @@ function main() {
                 item.name === mainComponent.name
                 ? mainComponent.parent.name
                 : item.name;
+            const propDefinitions = (mainComponent === null || mainComponent === void 0 ? void 0 : mainComponent.componentPropertyDefinitions) || {};
+            const keyNameMap = {};
+            for (const key in propDefinitions) {
+                const def = propDefinitions[key];
+                if (def && typeof def === 'object' && 'name' in def) {
+                    keyNameMap[key] = def.name;
+                }
+            }
+            const getPropName = (key) => keyNameMap[key] || key;
             const lines = [componentName];
             for (const key in variantProps) {
-                lines.push(`${key}: ${variantProps[key]}`);
+                const name = getPropName(key);
+                lines.push(`${name}: ${variantProps[key]}`);
             }
             for (const key in componentProps) {
                 const prop = componentProps[key];
@@ -47,7 +57,8 @@ function main() {
                     continue;
                 }
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-                lines.push(`${key}: ${value}`);
+                const name = getPropName(key);
+                lines.push(`${name}: ${value}`);
             }
             const propString = lines.join('\n');
             const text = figma.createText();

--- a/code.js
+++ b/code.js
@@ -46,10 +46,18 @@ function main() {
                 }
             }
             const getPropName = (key) => keyNameMap[key] || key;
-            const lines = [componentName];
+            const lines = [];
+            const seen = new Set();
+            const addLine = (line) => {
+                if (!seen.has(line)) {
+                    lines.push(line);
+                    seen.add(line);
+                }
+            };
+            addLine(componentName);
             for (const key in variantProps) {
                 const name = getPropName(key);
-                lines.push(`${name}: ${variantProps[key]}`);
+                addLine(`${name}: ${variantProps[key]}`);
             }
             for (const key in componentProps) {
                 const prop = componentProps[key];
@@ -58,7 +66,7 @@ function main() {
                 }
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
                 const name = getPropName(key);
-                lines.push(`${name}: ${value}`);
+                addLine(`${name}: ${value}`);
             }
             const propString = lines.join('\n');
             const text = figma.createText();

--- a/code.ts
+++ b/code.ts
@@ -45,11 +45,21 @@ async function main() {
 
     const getPropName = (key: string) => keyNameMap[key] || key;
 
-    const lines: string[] = [componentName];
+    const lines: string[] = [];
+    const seen = new Set<string>();
+
+    const addLine = (line: string) => {
+      if (!seen.has(line)) {
+        lines.push(line);
+        seen.add(line);
+      }
+    };
+
+    addLine(componentName);
 
     for (const key in variantProps) {
       const name = getPropName(key);
-      lines.push(`${name}: ${variantProps[key]}`);
+      addLine(`${name}: ${variantProps[key]}`);
     }
 
     for (const key in componentProps) {
@@ -59,7 +69,7 @@ async function main() {
       }
       const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
       const name = getPropName(key);
-      lines.push(`${name}: ${value}`);
+      addLine(`${name}: ${value}`);
     }
 
     const propString = lines.join('\n');

--- a/code.ts
+++ b/code.ts
@@ -34,10 +34,22 @@ async function main() {
         ? mainComponent.parent.name
         : item.name;
 
+    const propDefinitions = (mainComponent as any)?.componentPropertyDefinitions || {};
+    const keyNameMap: { [key: string]: string } = {};
+    for (const key in propDefinitions) {
+      const def = propDefinitions[key];
+      if (def && typeof def === 'object' && 'name' in def) {
+        keyNameMap[key] = def.name as string;
+      }
+    }
+
+    const getPropName = (key: string) => keyNameMap[key] || key;
+
     const lines: string[] = [componentName];
 
     for (const key in variantProps) {
-      lines.push(`${key}: ${variantProps[key]}`);
+      const name = getPropName(key);
+      lines.push(`${name}: ${variantProps[key]}`);
     }
 
     for (const key in componentProps) {
@@ -46,7 +58,8 @@ async function main() {
         continue;
       }
       const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-      lines.push(`${key}: ${value}`);
+      const name = getPropName(key);
+      lines.push(`${name}: ${value}`);
     }
 
     const propString = lines.join('\n');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": ["es6"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "typeRoots": [
       "./node_modules/@types",
       "./node_modules/@figma"


### PR DESCRIPTION
## Summary
- Map component property IDs to their human-readable names using `mainComponent.componentPropertyDefinitions`
- Use mapped names when composing variant and component property annotation lines

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc86885448328850c9db6b035da8b