### PR TITLE
Color annotate title and values

### DIFF
--- a/code.js
+++ b/code.js
@@ -49,15 +49,25 @@ function main() {
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
                 lines.push(`${key}: ${value}`);
             }
-            const propString = lines.join('\n');
-            const text = figma.createText();
-            text.fontName = { family: 'Inter', style: 'Regular' };
-            text.fontSize = 16;
-            text.characters = propString;
-            text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
-            figma.currentPage.appendChild(text);
-            text.x = positionX;
-            text.y = positionY - text.height;
+            const valueString = lines.slice(1).join('\n');
+            const titleText = figma.createText();
+            titleText.fontName = { family: 'Inter', style: 'Bold' };
+            titleText.fontSize = 16;
+            titleText.characters = componentName;
+            titleText.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+            figma.currentPage.appendChild(titleText);
+            const valueText = figma.createText();
+            valueText.fontName = { family: 'Inter', style: 'Regular' };
+            valueText.fontSize = 16;
+            valueText.characters = valueString;
+            valueText.fills = [
+                { type: 'SOLID', color: { r: 1, g: 214 / 255, b: 20 / 255 } },
+            ];
+            figma.currentPage.appendChild(valueText);
+            titleText.x = positionX;
+            valueText.x = positionX;
+            valueText.y = positionY - valueText.height;
+            titleText.y = valueText.y - titleText.height;
         }
         figma.closePlugin('Annotating Variants');
     });

--- a/code.ts
+++ b/code.ts
@@ -49,16 +49,28 @@ async function main() {
       lines.push(`${key}: ${value}`);
     }
 
-    const propString = lines.join('\n');
+    const valueString = lines.slice(1).join('\n');
 
-    const text = figma.createText();
-    text.fontName = { family: 'Inter', style: 'Regular' };
-    text.fontSize = 16;
-    text.characters = propString;
-    text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
-    figma.currentPage.appendChild(text);
-    text.x = positionX;
-    text.y = positionY - text.height;
+    const titleText = figma.createText();
+    titleText.fontName = { family: 'Inter', style: 'Bold' };
+    titleText.fontSize = 16;
+    titleText.characters = componentName;
+    titleText.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+    figma.currentPage.appendChild(titleText);
+
+    const valueText = figma.createText();
+    valueText.fontName = { family: 'Inter', style: 'Regular' };
+    valueText.fontSize = 16;
+    valueText.characters = valueString;
+    valueText.fills = [
+      { type: 'SOLID', color: { r: 1, g: 214 / 255, b: 20 / 255 } },
+    ];
+    figma.currentPage.appendChild(valueText);
+
+    titleText.x = positionX;
+    valueText.x = positionX;
+    valueText.y = positionY - valueText.height;
+    titleText.y = valueText.y - titleText.height;
   }
 
   figma.closePlugin('Annotating Variants');


### PR DESCRIPTION
## Summary
- add separate text nodes for titles and values with distinct fills
- color titles white and values #FFD614 for better annotation contrast

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc8677db08328be69e6e504c42ac2