### PR TITLE
Add styled annotation frame and connector arrow

### DIFF
--- a/code.js
+++ b/code.js
@@ -55,9 +55,29 @@ function main() {
             text.fontSize = 16;
             text.characters = propString;
             text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
-            figma.currentPage.appendChild(text);
-            text.x = positionX;
-            text.y = positionY - text.height;
+            const frame = figma.createFrame();
+            frame.layoutMode = 'VERTICAL';
+            frame.counterAxisSizingMode = 'AUTO';
+            frame.primaryAxisSizingMode = 'AUTO';
+            frame.paddingLeft = frame.paddingRight = frame.paddingTop = frame.paddingBottom = 8;
+            frame.strokes = [
+                { type: 'SOLID', color: { r: 0.48235294, g: 0.38039216, b: 1 } },
+            ];
+            frame.strokeWeight = 1;
+            frame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+            frame.appendChild(text);
+            figma.currentPage.appendChild(frame);
+            frame.x = positionX;
+            frame.y = positionY - frame.height;
+            const connector = figma.createConnector();
+            connector.connectorStart = { endpointNodeId: frame.id, magnet: 'BOTTOM' };
+            connector.connectorEnd = { endpointNodeId: item.id, magnet: 'TOP' };
+            connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+            connector.strokes = [
+                { type: 'SOLID', color: { r: 0.48235294, g: 0.38039216, b: 1 } },
+            ];
+            connector.strokeWeight = 2;
+            figma.currentPage.appendChild(connector);
         }
         figma.closePlugin('Annotating Variants');
     });

--- a/code.ts
+++ b/code.ts
@@ -56,9 +56,31 @@ async function main() {
     text.fontSize = 16;
     text.characters = propString;
     text.setRangeFontName(0, componentName.length, { family: 'Inter', style: 'Bold' });
-    figma.currentPage.appendChild(text);
-    text.x = positionX;
-    text.y = positionY - text.height;
+
+    const frame = figma.createFrame();
+    frame.layoutMode = 'VERTICAL';
+    frame.counterAxisSizingMode = 'AUTO';
+    frame.primaryAxisSizingMode = 'AUTO';
+    frame.paddingLeft = frame.paddingRight = frame.paddingTop = frame.paddingBottom = 8;
+    frame.strokes = [
+      { type: 'SOLID', color: { r: 0.48235294, g: 0.38039216, b: 1 } },
+    ];
+    frame.strokeWeight = 1;
+    frame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+    frame.appendChild(text);
+    figma.currentPage.appendChild(frame);
+    frame.x = positionX;
+    frame.y = positionY - frame.height;
+
+    const connector = figma.createConnector();
+    connector.connectorStart = { endpointNodeId: frame.id, magnet: 'BOTTOM' };
+    connector.connectorEnd = { endpointNodeId: item.id, magnet: 'TOP' };
+    connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+    connector.strokes = [
+      { type: 'SOLID', color: { r: 0.48235294, g: 0.38039216, b: 1 } },
+    ];
+    connector.strokeWeight = 2;
+    figma.currentPage.appendChild(connector);
   }
 
   figma.closePlugin('Annotating Variants');


### PR DESCRIPTION
## Summary
- Wrap annotation text in a styled frame with solid stroke and white fill
- Draw connector arrow from frame to component instance with violet stroke

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc863b6a48328b16a493a2c844b60