### PR TITLE
Style variant annotations in auto-layout frame with progress

### DIFF
--- a/code.js
+++ b/code.js
@@ -10,55 +10,108 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 if (figma.currentPage.selection.length === 0) {
     figma.closePlugin("Nothing selected. Please select component instances to annotate.");
 }
+figma.showUI(__html__, { width: 160, height: 60 });
 function main() {
-    var _a;
+    var _a, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
-        yield figma.loadFontAsync({ family: 'Roboto Mono', style: 'Regular' });
-        yield figma.loadFontAsync({ family: 'Roboto Mono', style: 'Bold' });
+        try {
+            yield Promise.all([
+                figma.loadFontAsync({ family: 'Roboto Mono', style: 'Regular' }),
+                figma.loadFontAsync({ family: 'Roboto Mono', style: 'Bold' }),
+            ]);
+        }
+        catch (_d) {
+            figma.closePlugin('Roboto Mono font is not available.');
+            return;
+        }
         const selectedInstances = figma.currentPage.selection;
-        for (const item of selectedInstances) {
+        const total = selectedInstances.length;
+        for (let index = 0; index < total; index++) {
+            const item = selectedInstances[index];
             if (item.type !== 'INSTANCE') {
                 figma.closePlugin('Please select ONLY component instances to annotate.');
                 return;
             }
+            figma.ui.postMessage({ type: 'progress', current: index + 1, total });
             const variantProps = item.variantProperties || {};
             const componentProps = item.componentProperties || {};
             const hasVariantProps = Object.keys(variantProps).length > 0;
             const hasComponentProps = Object.keys(componentProps).length > 0;
             if (!hasVariantProps && !hasComponentProps) {
-                figma.closePlugin('No variant or component properties found.');
-                return;
+                continue;
             }
-            const positionX = item.absoluteRenderBounds.x;
-            const positionY = item.absoluteRenderBounds.y - 80;
+            const bounds = item.absoluteRenderBounds;
             const mainComponent = item.mainComponent;
             const componentName = mainComponent &&
                 ((_a = mainComponent.parent) === null || _a === void 0 ? void 0 : _a.type) === 'COMPONENT_SET' &&
                 item.name === mainComponent.name
                 ? mainComponent.parent.name
                 : item.name;
-            const lines = [componentName];
+            const linePairs = [
+                { title: 'Component', value: componentName },
+            ];
             for (const key in variantProps) {
-                lines.push(`${key}: ${variantProps[key]}`);
+                linePairs.push({ title: key, value: String(variantProps[key]) });
             }
+            const definitions = (mainComponent === null || mainComponent === void 0 ? void 0 : mainComponent.componentPropertyDefinitions) || {};
             for (const key in componentProps) {
                 const prop = componentProps[key];
                 if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
                     continue;
                 }
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-                lines.push(`${key}: ${value}`);
+                const name = (_c = (_b = definitions[key]) === null || _b === void 0 ? void 0 : _b.name) !== null && _c !== void 0 ? _c : key;
+                linePairs.push({ title: name, value: String(value) });
             }
-            const propString = lines.join('\n');
-            const text = figma.createText();
-            text.fontName = { family: 'Roboto Mono', style: 'Regular' };
-            text.fontSize = 16;
-            text.characters = propString;
-            text.setRangeFontName(0, componentName.length, { family: 'Roboto Mono', style: 'Bold' });
-            figma.currentPage.appendChild(text);
-            text.x = positionX;
-            text.y = positionY - text.height;
+            const primaryFrame = figma.createFrame();
+            primaryFrame.layoutMode = 'VERTICAL';
+            primaryFrame.primaryAxisSizingMode = 'AUTO';
+            primaryFrame.counterAxisSizingMode = 'AUTO';
+            primaryFrame.paddingLeft = primaryFrame.paddingRight = 8;
+            primaryFrame.paddingTop = primaryFrame.paddingBottom = 8;
+            primaryFrame.itemSpacing = 4;
+            primaryFrame.cornerRadius = 2;
+            primaryFrame.fills = [
+                { type: 'SOLID', color: { r: 18 / 255, g: 18 / 255, b: 18 / 255 }, opacity: 0.3 },
+            ];
+            primaryFrame.strokes = [
+                { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+            ];
+            primaryFrame.strokeWeight = 1;
+            for (const pair of linePairs) {
+                const row = figma.createFrame();
+                row.layoutMode = 'HORIZONTAL';
+                row.primaryAxisSizingMode = 'AUTO';
+                row.counterAxisSizingMode = 'AUTO';
+                row.itemSpacing = 4;
+                const titleNode = figma.createText();
+                titleNode.fontName = { family: 'Roboto Mono', style: 'Regular' };
+                titleNode.characters = `${pair.title}:`;
+                titleNode.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+                const valueNode = figma.createText();
+                valueNode.fontName = { family: 'Roboto Mono', style: 'Regular' };
+                valueNode.characters = pair.value;
+                valueNode.fills = [{ type: 'SOLID', color: { r: 1, g: 0.839, b: 0.078 } }];
+                row.appendChild(titleNode);
+                row.appendChild(valueNode);
+                primaryFrame.appendChild(row);
+            }
+            figma.currentPage.appendChild(primaryFrame);
+            primaryFrame.x = bounds.x;
+            const offset = 16;
+            primaryFrame.y = bounds.y - primaryFrame.height - offset;
+            const connector = figma.createConnector();
+            connector.strokeWeight = 1;
+            connector.strokes = [
+                { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+            ];
+            connector.connectorStart = { endpointNodeId: primaryFrame.id, magnet: 'AUTO' };
+            connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
+            connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+            figma.currentPage.appendChild(connector);
+            yield new Promise((r) => setTimeout(r, 0));
         }
+        figma.ui.postMessage({ type: 'complete' });
         figma.closePlugin('Annotating Variants');
     });
 }

--- a/code.ts
+++ b/code.ts
@@ -2,17 +2,30 @@ if (figma.currentPage.selection.length === 0) {
   figma.closePlugin("Nothing selected. Please select component instances to annotate.");
 }
 
+figma.showUI(__html__, { width: 160, height: 60 });
+
 async function main() {
-  await figma.loadFontAsync({ family: 'Roboto Mono', style: 'Regular' });
-  await figma.loadFontAsync({ family: 'Roboto Mono', style: 'Bold' });
+  try {
+    await Promise.all([
+      figma.loadFontAsync({ family: 'Roboto Mono', style: 'Regular' }),
+      figma.loadFontAsync({ family: 'Roboto Mono', style: 'Bold' }),
+    ]);
+  } catch {
+    figma.closePlugin('Roboto Mono font is not available.');
+    return;
+  }
 
   const selectedInstances = figma.currentPage.selection;
+  const total = selectedInstances.length;
 
-  for (const item of selectedInstances) {
+  for (let index = 0; index < total; index++) {
+    const item = selectedInstances[index];
     if (item.type !== 'INSTANCE') {
       figma.closePlugin('Please select ONLY component instances to annotate.');
       return;
     }
+
+    figma.ui.postMessage({ type: 'progress', current: index + 1, total });
 
     const variantProps = item.variantProperties || {};
     const componentProps: { [key: string]: any } = (item as any).componentProperties || {};
@@ -20,12 +33,10 @@ async function main() {
     const hasVariantProps = Object.keys(variantProps).length > 0;
     const hasComponentProps = Object.keys(componentProps).length > 0;
     if (!hasVariantProps && !hasComponentProps) {
-      figma.closePlugin('No variant or component properties found.');
-      return;
+      continue;
     }
 
-    const positionX = item.absoluteRenderBounds!.x;
-    const positionY = item.absoluteRenderBounds!.y - 80;
+    const bounds = item.absoluteRenderBounds!;
     const mainComponent = item.mainComponent;
     const componentName =
       mainComponent &&
@@ -34,33 +45,83 @@ async function main() {
         ? mainComponent.parent.name
         : item.name;
 
-    const lines: string[] = [componentName];
+    const linePairs: { title: string; value: string }[] = [
+      { title: 'Component', value: componentName },
+    ];
 
     for (const key in variantProps) {
-      lines.push(`${key}: ${variantProps[key]}`);
+      linePairs.push({ title: key, value: String(variantProps[key]) });
     }
 
+    const definitions = (mainComponent as any)?.componentPropertyDefinitions || {};
     for (const key in componentProps) {
       const prop = componentProps[key];
       if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
         continue;
       }
-      const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-      lines.push(`${key}: ${value}`);
+      const value =
+        typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
+      const name = (definitions as any)[key]?.name ?? key;
+      linePairs.push({ title: name, value: String(value) });
     }
 
-    const propString = lines.join('\n');
+    const primaryFrame = figma.createFrame();
+    primaryFrame.layoutMode = 'VERTICAL';
+    primaryFrame.primaryAxisSizingMode = 'AUTO';
+    primaryFrame.counterAxisSizingMode = 'AUTO';
+    primaryFrame.paddingLeft = primaryFrame.paddingRight = 8;
+    primaryFrame.paddingTop = primaryFrame.paddingBottom = 8;
+    primaryFrame.itemSpacing = 4;
+    primaryFrame.cornerRadius = 2;
+    primaryFrame.fills = [
+      { type: 'SOLID', color: { r: 18 / 255, g: 18 / 255, b: 18 / 255 }, opacity: 0.3 },
+    ];
+    primaryFrame.strokes = [
+      { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+    ];
+    primaryFrame.strokeWeight = 1;
 
-    const text = figma.createText();
-    text.fontName = { family: 'Roboto Mono', style: 'Regular' };
-    text.fontSize = 16;
-    text.characters = propString;
-    text.setRangeFontName(0, componentName.length, { family: 'Roboto Mono', style: 'Bold' });
-    figma.currentPage.appendChild(text);
-    text.x = positionX;
-    text.y = positionY - text.height;
+    for (const pair of linePairs) {
+      const row = figma.createFrame();
+      row.layoutMode = 'HORIZONTAL';
+      row.primaryAxisSizingMode = 'AUTO';
+      row.counterAxisSizingMode = 'AUTO';
+      row.itemSpacing = 4;
+
+      const titleNode = figma.createText();
+      titleNode.fontName = { family: 'Roboto Mono', style: 'Regular' };
+      titleNode.characters = `${pair.title}:`;
+      titleNode.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+
+      const valueNode = figma.createText();
+      valueNode.fontName = { family: 'Roboto Mono', style: 'Regular' };
+      valueNode.characters = pair.value;
+      valueNode.fills = [{ type: 'SOLID', color: { r: 1, g: 0.839, b: 0.078 } }];
+
+      row.appendChild(titleNode);
+      row.appendChild(valueNode);
+      primaryFrame.appendChild(row);
+    }
+
+    figma.currentPage.appendChild(primaryFrame);
+    primaryFrame.x = bounds.x;
+    const offset = 16;
+    primaryFrame.y = bounds.y - primaryFrame.height - offset;
+
+    const connector = figma.createConnector();
+    connector.strokeWeight = 1;
+    connector.strokes = [
+      { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+    ];
+    connector.connectorStart = { endpointNodeId: primaryFrame.id, magnet: 'AUTO' };
+    connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
+    connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+    figma.currentPage.appendChild(connector);
+
+    await new Promise((r) => setTimeout(r, 0));
   }
 
+  figma.ui.postMessage({ type: 'complete' });
   figma.closePlugin('Annotating Variants');
 }
 

--- a/ui.html
+++ b/ui.html
@@ -1,17 +1,12 @@
-<h2>Rectangle Creator</h2>
-<p>Count: <input id="count" value="5"></p>
-<button id="create">Create</button>
-<button id="cancel">Cancel</button>
+<div id="progress">Starting...</div>
 <script>
-
-document.getElementById('create').onclick = () => {
-  const textbox = document.getElementById('count');
-  const count = parseInt(textbox.value, 10);
-  parent.postMessage({ pluginMessage: { type: 'create-rectangles', count } }, '*')
-}
-
-document.getElementById('cancel').onclick = () => {
-  parent.postMessage({ pluginMessage: { type: 'cancel' } }, '*')
-}
-
+onmessage = (event) => {
+  const msg = event.data.pluginMessage;
+  if (msg.type === 'progress') {
+    const { current, total } = msg;
+    document.getElementById('progress').textContent = `Annotation ${current} / ${total}`;
+  } else if (msg.type === 'complete') {
+    document.getElementById('progress').textContent = 'Done';
+  }
+};
 </script>


### PR DESCRIPTION
## Summary
- Show progress UI while rendering annotations and throttle creation
- Wrap annotation details in styled auto-layout frame and separate title/value rows
- Connect annotation frame to instance with purple arrow and strip numeric property IDs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc590864883289944d9b6ee4f42ea