### PR TITLE
Add fallback arrow line when createConnector is unavailable

### DIFF
--- a/code.js
+++ b/code.js
@@ -100,15 +100,44 @@ function main() {
             primaryFrame.x = bounds.x;
             const offset = 16;
             primaryFrame.y = bounds.y - primaryFrame.height - offset;
-            const connector = figma.createConnector();
-            connector.strokeWeight = 1;
-            connector.strokes = [
-                { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
-            ];
-            connector.connectorStart = { endpointNodeId: primaryFrame.id, magnet: 'AUTO' };
-            connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
-            connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
-            figma.currentPage.appendChild(connector);
+            try {
+                if ('createConnector' in figma) {
+                    const connector = figma.createConnector();
+                    connector.strokeWeight = 1;
+                    connector.strokes = [
+                        { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+                    ];
+                    connector.connectorStart = {
+                        endpointNodeId: primaryFrame.id,
+                        magnet: 'AUTO',
+                    };
+                    connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
+                    connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+                    figma.currentPage.appendChild(connector);
+                }
+                else {
+                    const line = figma.createLine();
+                    line.strokeWeight = 1;
+                    line.strokes = [
+                        { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+                    ];
+                    const startX = primaryFrame.x + primaryFrame.width / 2;
+                    const startY = primaryFrame.y + primaryFrame.height;
+                    const endX = item.x + item.width / 2;
+                    const endY = item.y;
+                    const dx = endX - startX;
+                    const dy = endY - startY;
+                    const length = Math.sqrt(dx * dx + dy * dy);
+                    line.x = startX;
+                    line.y = startY;
+                    line.resize(length, 0);
+                    line.rotation = (Math.atan2(dy, dx) * 180) / Math.PI;
+                    figma.currentPage.appendChild(line);
+                }
+            }
+            catch (error) {
+                console.error('Failed to create connector', error);
+            }
             yield new Promise((r) => setTimeout(r, 0));
         }
         figma.ui.postMessage({ type: 'complete' });

--- a/code.ts
+++ b/code.ts
@@ -108,15 +108,42 @@ async function main() {
     const offset = 16;
     primaryFrame.y = bounds.y - primaryFrame.height - offset;
 
-    const connector = figma.createConnector();
-    connector.strokeWeight = 1;
-    connector.strokes = [
-      { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
-    ];
-    connector.connectorStart = { endpointNodeId: primaryFrame.id, magnet: 'AUTO' };
-    connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
-    connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
-    figma.currentPage.appendChild(connector);
+    try {
+      if ('createConnector' in figma) {
+        const connector = figma.createConnector();
+        connector.strokeWeight = 1;
+        connector.strokes = [
+          { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+        ];
+        connector.connectorStart = {
+          endpointNodeId: primaryFrame.id,
+          magnet: 'AUTO',
+        };
+        connector.connectorEnd = { endpointNodeId: item.id, magnet: 'AUTO' };
+        connector.connectorEndStrokeCap = 'ARROW_EQUILATERAL';
+        figma.currentPage.appendChild(connector);
+      } else {
+        const line = figma.createLine();
+        line.strokeWeight = 1;
+        line.strokes = [
+          { type: 'SOLID', color: { r: 123 / 255, g: 97 / 255, b: 1 } },
+        ];
+        const startX = primaryFrame.x + primaryFrame.width / 2;
+        const startY = primaryFrame.y + primaryFrame.height;
+        const endX = item.x + item.width / 2;
+        const endY = item.y;
+        const dx = endX - startX;
+        const dy = endY - startY;
+        const length = Math.sqrt(dx * dx + dy * dy);
+        line.x = startX;
+        line.y = startY;
+        line.resize(length, 0);
+        line.rotation = (Math.atan2(dy, dx) * 180) / Math.PI;
+        figma.currentPage.appendChild(line);
+      }
+    } catch (error) {
+      console.error('Failed to create connector', error);
+    }
 
     await new Promise((r) => setTimeout(r, 0));
   }


### PR DESCRIPTION
## Summary
- Safely attempt arrow creation with try/catch
- Use connector when `figma.createConnector` exists
- Draw styled line between nodes when connectors are unsupported

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bdb705a2f08328bf527fc9d1bae748