### PR TITLE
Notify when instance has no annotatable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Variant Annotator
 
 Annotate variant and component properties for multiple components. Just select component instances and run the plugin. A text box is generated with the component name and its properties for every selection. This makes annotating components a breeze, especially while creating component specifications.
+
+If a selected instance has no variant or component properties, the plugin now notifies you that it has no annotatable properties.

--- a/code.js
+++ b/code.js
@@ -38,6 +38,7 @@ function main() {
             const hasVariantProps = Object.keys(variantProps).length > 0;
             const hasComponentProps = Object.keys(componentProps).length > 0;
             if (!hasVariantProps && !hasComponentProps) {
+                figma.notify(`Instance "${item.name}" has no annotatable properties.`);
                 continue;
             }
             const bounds = item.absoluteRenderBounds;

--- a/code.ts
+++ b/code.ts
@@ -33,6 +33,7 @@ async function main() {
     const hasVariantProps = Object.keys(variantProps).length > 0;
     const hasComponentProps = Object.keys(componentProps).length > 0;
     if (!hasVariantProps && !hasComponentProps) {
+      figma.notify(`Instance "${item.name}" has no annotatable properties.`);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- notify users when a selected instance lacks variant or component properties
- document notification behavior in README

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bdb8700f7483288622ae8acdcf1ec3