### PR TITLE
Map component property IDs to names

### DIFF
--- a/code.js
+++ b/code.js
@@ -37,17 +37,29 @@ function main() {
                 item.name === mainComponent.name
                 ? mainComponent.parent.name
                 : item.name;
+            const propDefinitions = (mainComponent === null || mainComponent === void 0 ? void 0 : mainComponent.componentPropertyDefinitions) || {};
+            const propIdNameMap = {};
+            for (const id in propDefinitions) {
+                const def = propDefinitions[id];
+                if (def && typeof def === 'object' && 'name' in def) {
+                    propIdNameMap[id] = def.name;
+                }
+            }
             const lines = [componentName];
             for (const key in variantProps) {
                 lines.push(`${key}: ${variantProps[key]}`);
             }
             for (const key in componentProps) {
+                const name = propIdNameMap[key];
+                if (!name) {
+                    continue;
+                }
                 const prop = componentProps[key];
                 if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
                     continue;
                 }
                 const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-                lines.push(`${key}: ${value}`);
+                lines.push(`${name}: ${value}`);
             }
             const propString = lines.join('\n');
             const text = figma.createText();

--- a/code.ts
+++ b/code.ts
@@ -34,6 +34,16 @@ async function main() {
         ? mainComponent.parent.name
         : item.name;
 
+    const propDefinitions: { [key: string]: any } =
+      (mainComponent as any)?.componentPropertyDefinitions || {};
+    const propIdNameMap: { [id: string]: string } = {};
+    for (const id in propDefinitions) {
+      const def = propDefinitions[id];
+      if (def && typeof def === 'object' && 'name' in def) {
+        propIdNameMap[id] = def.name;
+      }
+    }
+
     const lines: string[] = [componentName];
 
     for (const key in variantProps) {
@@ -41,12 +51,17 @@ async function main() {
     }
 
     for (const key in componentProps) {
+      const name = propIdNameMap[key];
+      if (!name) {
+        continue;
+      }
       const prop = componentProps[key];
       if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
         continue;
       }
-      const value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
-      lines.push(`${key}: ${value}`);
+      const value =
+        typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
+      lines.push(`${name}: ${value}`);
     }
 
     const propString = lines.join('\n');


### PR DESCRIPTION
## Summary
- Build map of component property definitions to resolve IDs to readable names
- Replace component property IDs with mapped names while skipping undefined and VARIANT properties

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0b3eacb0483288e2bf822d6a38b5e