### PR TITLE
Skip invisible component properties

### DIFF
--- a/code.js
+++ b/code.js
@@ -56,6 +56,9 @@ function main() {
                 if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
                     continue;
                 }
+                if (typeof prop === 'object' && prop !== null && 'visible' in prop && !prop.visible) {
+                    continue;
+                }
                 let value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
                 if (typeof value === 'string') {
                     value = sanitizeName(value);

--- a/code.ts
+++ b/code.ts
@@ -57,6 +57,9 @@ async function main() {
       if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
         continue;
       }
+      if (typeof prop === 'object' && prop !== null && 'visible' in prop && !prop.visible) {
+        continue;
+      }
       let value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
       if (typeof value === 'string') {
         value = sanitizeName(value);


### PR DESCRIPTION
## Summary
- skip component properties flagged as not visible when building annotations
- compile the TypeScript source to refresh the JavaScript bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8a198e1a0832894676027324af7e1