### PR TITLE
Respect dependent component property visibility

### DIFF
--- a/code.js
+++ b/code.js
@@ -51,11 +51,43 @@ function main() {
                 lines.push(`${sanitizedKey}: ${value}`);
             }
             for (const key in componentProps) {
-                const sanitizedKey = sanitizeName(key);
                 const prop = componentProps[key];
                 if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
                     continue;
                 }
+                if (typeof prop === 'object' && prop !== null) {
+                    let isVisible = true;
+                    const visibility = prop.visible;
+                    if (typeof visibility === 'boolean') {
+                        isVisible = visibility;
+                    }
+                    else if (typeof visibility === 'string') {
+                        const controller = componentProps[visibility];
+                        const controllerValue = typeof controller === 'object' && controller !== null && 'value' in controller
+                            ? controller.value
+                            : controller;
+                        isVisible = Boolean(controllerValue);
+                    }
+                    else if (visibility && typeof visibility === 'object') {
+                        const propertyName = visibility.propertyName;
+                        if (propertyName) {
+                            const controller = componentProps[propertyName];
+                            const controllerValue = typeof controller === 'object' && controller !== null && 'value' in controller
+                                ? controller.value
+                                : controller;
+                            if ('value' in visibility) {
+                                isVisible = controllerValue === visibility.value;
+                            }
+                            else {
+                                isVisible = Boolean(controllerValue);
+                            }
+                        }
+                    }
+                    if (!isVisible) {
+                        continue;
+                    }
+                }
+                const sanitizedKey = sanitizeName(key);
                 let value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
                 if (typeof value === 'string') {
                     value = sanitizeName(value);

--- a/code.ts
+++ b/code.ts
@@ -52,11 +52,46 @@ async function main() {
     }
 
     for (const key in componentProps) {
-      const sanitizedKey = sanitizeName(key);
       const prop = componentProps[key];
       if (typeof prop === 'object' && prop !== null && prop.type === 'VARIANT') {
         continue;
       }
+
+      if (typeof prop === 'object' && prop !== null) {
+        let isVisible = true;
+        const visibility = (prop as any).visible;
+
+        if (typeof visibility === 'boolean') {
+          isVisible = visibility;
+        } else if (typeof visibility === 'string') {
+          const controller = componentProps[visibility];
+          const controllerValue =
+            typeof controller === 'object' && controller !== null && 'value' in controller
+              ? controller.value
+              : controller;
+          isVisible = Boolean(controllerValue);
+        } else if (visibility && typeof visibility === 'object') {
+          const propertyName = (visibility as any).propertyName;
+          if (propertyName) {
+            const controller = componentProps[propertyName];
+            const controllerValue =
+              typeof controller === 'object' && controller !== null && 'value' in controller
+                ? controller.value
+                : controller;
+            if ('value' in (visibility as any)) {
+              isVisible = controllerValue === (visibility as any).value;
+            } else {
+              isVisible = Boolean(controllerValue);
+            }
+          }
+        }
+
+        if (!isVisible) {
+          continue;
+        }
+      }
+
+      const sanitizedKey = sanitizeName(key);
       let value = typeof prop === 'object' && prop !== null && 'value' in prop ? prop.value : prop;
       if (typeof value === 'string') {
         value = sanitizeName(value);


### PR DESCRIPTION
## Summary
- evaluate component property visibility dependencies before including them in annotations
- derive dependent visibility from controlling component properties and skip hidden entries
- rebuild the compiled plugin bundle to capture the new visibility handling logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8a198e1a0832894676027324af7e1